### PR TITLE
Build lua as cpp

### DIFF
--- a/KernelLuaVm/lua/state.hpp
+++ b/KernelLuaVm/lua/state.hpp
@@ -3,12 +3,10 @@
 #include <ntifs.h>
 #include "../logger.hpp"
 
-extern "C"
-{
-    #include <lua.h>
-    #include <lauxlib.h>
-    #include <lualib.h>
-};
+// Build lua as cpp 
+#include <lua.h>
+#include <lauxlib.h>
+#include <lualib.h>
 
 namespace lua
 {


### PR DESCRIPTION
Build lua as cpp

Why would you want to compile lua to C when you can do everything via CPP? Don't you think CPP exceptions are cooler?

try {} catch(...) {}
__try { } __except(filter){}